### PR TITLE
add prototype for upgrades

### DIFF
--- a/pyMuellerMat/components.py
+++ b/pyMuellerMat/components.py
@@ -1,0 +1,77 @@
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Optional, Callable
+from numpy.typing import NDArray
+import numpy as np
+import timeit
+from pydantic import BaseModel, Field
+import tomli
+import tomli_w
+import datetime
+
+from pyMuellerMat.mm_functions import lp_mm, wp_mm
+
+
+class System(BaseModel):
+    name: str = ""
+    filter: str = ""
+    date: datetime.date = datetime.date.today()
+    components: OrderedDict[str, Callable]
+
+    def __call__(self) -> NDArray:
+        mms = [comp() for comp in reversed(self.components.values())]
+        return np.linalg.multi_dot(mms)
+    
+    def to_dict(self) -> dict:
+        # get model as nested dictionary
+        # round-trip ensures sys can be recreated from output,
+        # and JSON makes sure all types are safe for serialization
+        return self.model_dump(mode="json", round_trip=True)
+
+
+class LinearPolarizer(BaseModel):
+    theta: float = 0
+
+    def __call__(self) -> NDArray:
+        return lp_mm(self.theta)
+
+class GenericWaveplate(BaseModel):
+    theta: float = 0
+    delta: float = 0
+
+    def __call__(self) -> NDArray:
+        return wp_mm(self.theta, self.delta)
+
+
+if __name__ == "__main__":
+    # demo
+    # generate circular polarized light
+    lp = LinearPolarizer(theta=0)
+    qwp = GenericWaveplate(theta=np.pi/4, delta=np.pi/2)
+    sys = System(
+        name="test",
+        filter="Open",
+        components=OrderedDict(lp=lp, qwp=qwp)
+    )
+    
+    M = sys()
+    np.set_printoptions(suppress=True)
+    print(M)
+    S = np.array((1, 0, 0, 0))
+    print(S)
+    print(M @ S)
+
+    res = timeit.timeit(sys, number=10000)
+    print(f"Average time to evaluate MM (n=1e4): {res*1e3:.02e} ms")
+
+
+    model_dict = sys.to_dict()
+
+    import pprint
+    print("Model as dictionary")
+    print("-------------------")
+    pprint.pprint(model_dict)
+
+    print("\nModel as TOML")
+    print("-------------------")
+    print(tomli_w.dumps(model_dict))

--- a/pyMuellerMat/components.py
+++ b/pyMuellerMat/components.py
@@ -1,11 +1,9 @@
 from collections import OrderedDict
-from dataclasses import dataclass
-from typing import Any, Optional, Callable
+from typing import Callable
 from numpy.typing import NDArray
 import numpy as np
 import timeit
-from pydantic import BaseModel, Field
-import tomli
+from pydantic import BaseModel
 import tomli_w
 import datetime
 

--- a/pyMuellerMat/mm_functions.py
+++ b/pyMuellerMat/mm_functions.py
@@ -1,0 +1,54 @@
+import numba
+import numpy as np
+
+@numba.njit()
+def lp_mm(theta: float = 0):
+    """
+    Rotated linear polarizer
+
+    Parameters
+    ----------
+    theta : float
+        Angle of polarization in radians.
+
+    Notes
+    -----
+    Chipman 2019, Eq. 6.37
+    """
+    cos2th = np.cos(2 * theta)
+    sin2th = np.sin(2 * theta)
+    mm = 0.5 * np.array((
+        (1, cos2th, sin2th, 0),
+        (cos2th, cos2th**2, sin2th * cos2th, 0),
+        (sin2th, sin2th * cos2th, sin2th**2, 0),
+        (0, 0, 0, 0)
+    ), dtype="f4")
+    return mm
+
+@numba.njit()
+def wp_mm(theta: float = 0, delta: float = 0):
+    """
+    Rotated generic waveplate
+
+    Parameters
+    ----------
+    theta : float
+        Angle of fast axis in radians.
+    delta : float
+        Retardance in radians. For HWP use pi, for QWP use pi/2, etc.
+
+    Notes
+    -----
+    Chipman 2019, Eq. 6.23
+    """
+    cos2th = np.cos(2 * theta)
+    sin2th = np.sin(2 * theta)
+    cosd = np.cos(delta)
+    sind = np.sin(delta)
+    mm = np.array((
+        (1, 0, 0, 0),
+        (0, cos2th**2 + cosd * sin2th**2, (1 - cosd) * cos2th * sin2th, -sind * sin2th),
+        (0, (1 - cosd) * cos2th * sin2th, cosd * cos2th**2 + sin2th**2, cos2th * sind),
+        (0, sind * sin2th, -cos2th * sind, cosd)
+    ), dtype="f4")
+    return mm


### PR DESCRIPTION
Prototype of new design for PyMuellerMat (#2)

In this PR you can see two new files:
- `mm_functions.py` - this has numba-accelerated fast Mueller-matrix implementations
- `components.py` - this has the nice class-based component and system models

If you run

    python pyMuellerMat/components.py

you will see a demo of the prototype.

**Numba vs. Numpy**
I performed some micro-benchmarks using the two-component system in `components.py`. I used `timeit` with 10,000 iterations and numba improved on numpy by a factor of ~2x (20 ms vs. 40 ms). More extensive benchmarks, preferably built into some automated tests.

**File IO**
By using `pydantic` we get really easy-to-use serialization of the component classes to dictionaries (which can be saved to TOML, JSON, YAML, etc.). I'm a fan of TOML, personally- this is the exact same system I've built the VAMPIRES DPP configuration off of. If you run the `components.py` file you'll see an example of the dictionary and TOML outputs from the `System` class.

My thinking is that we can save these TOML files in zenodo or on google drive and then that's really easy for me to download to the DPP and load back using pyMuellerMat.
